### PR TITLE
Fixes while working with podman

### DIFF
--- a/plans/in_one_container.pp
+++ b/plans/in_one_container.pp
@@ -16,7 +16,7 @@ plan pulp3::in_one_container (
     [ "${container_root}/run/ISOs/unpacked" ]
   },
 ) {
-  $host = run_plan('pulp3::in_one_container::get_host', 'targets'              => $targets, 'runtime' => $runtime)
+  $host = run_plan('pulp3::in_one_container::get_host', 'targets' => $targets, 'runtime' => $runtime)
   $runtime_exe            = $host.facts['pioc_runtime_exe']
   $apply_el7_docker_fixes = $host.facts['pioc_apply_el7_docker_fixes']
 
@@ -33,6 +33,7 @@ plan pulp3::in_one_container (
     'host'  => $host,
     'name'  => $container_name,
     'image' => $container_image,
+    'port'  => $container_port,
     'all'   => true,
   }){
     out::message( "Restarting stopped container '${container_name}'..." )
@@ -57,11 +58,11 @@ plan pulp3::in_one_container (
       --publish-all \
       --log-driver journald \
       --device /dev/fuse \
-      --volume "pulp-settings:/etc/pulp" \
-      --volume "pulp-storage:/var/lib/pulp" \
-      --volume "pulp-pgsql:/var/lib/pgsql" \
-      --volume "pulp-containers:/var/lib/containers" \
-      --volume "pulp-run:/run" \
+      --volume "${container_name}-settings:/etc/pulp" \
+      --volume "${container_name}-storage:/var/lib/pulp" \
+      --volume "${container_name}-pgsql:/var/lib/pgsql" \
+      --volume "${container_name}-containers:/var/lib/containers" \
+      --volume "${container_name}-run:/run" \
       "${container_image}"
     | START_CMD
 

--- a/plans/in_one_container/match_container.pp
+++ b/plans/in_one_container/match_container.pp
@@ -4,20 +4,52 @@
 #
 # Details at https://pulpproject.org/pulp-in-one-container/
 plan pulp3::in_one_container::match_container(
-  TargetSpec $host,
-  Boolean    $all = false,
-  String[1]  $name  = lookup('pulp3::in_one_container::container_name')|$k|{'pulp'},
-  String[1]  $image = lookup('pulp3::in_one_container::container_image')|$k|{'pulp/pulp'},
+  TargetSpec             $host,
+  Boolean                $all   = false,
+  String[1]              $name  = lookup('pulp3::in_one_container::container_name')|$k|{'pulp'},
+  String[1]              $image = lookup('pulp3::in_one_container::container_image')|$k|{'pulp/pulp'},
+  Optional[Stdlib::Port] $port  = undef,
+  Optional[String[1]]    $runtime_exe = $host.facts['pioc_runtime_exe']
 ) {
   $extra_args  = $all ? { true => '-a', default => '' }
-  $runtime_exe = $host.facts['pioc_runtime_exe']
 
   $ls_result = run_command(
-    "${runtime_exe} container ls ${extra_args} --format='{{.Image}}  {{.ID}}  {{.Names}}'",
+    "${runtime_exe} container ls ${extra_args} --format='{{.Names}}|{{.ID}}|{{.Image}}|{{.Ports}}'",
     $host,
   )
-  if $ls_result[0].value['stdout'].split("\n").any |$x| {
-    $x.match("^${image}.*${name}$")
-  }{ return true }
+
+  $ls_nodes = Hash(
+    $ls_result[0].value['stdout'].split("\n").map |$x| {
+      $node_parts = $x.strip.split('\|')
+
+      if $node_parts[3] {
+        $node_ports = Integer($node_parts[3].split('->')[0].split(':')[-1])
+      }
+      else {
+        $node_ports = undef
+      }
+
+      [
+        $node_parts[0],
+        {
+          'id'    => $node_parts[1],
+          'image' => $node_parts[2],
+          'ports' => [$node_ports],
+          'raw'   => $x.regsubst('\|','  ','G')
+        }
+      ]
+    }
+  )
+
+  if $ls_nodes[$name] {
+    if $ls_nodes[$name]['image'] == $image {
+      if $port and !( $port in $ls_nodes[$name]['ports'] ) {
+        fail_plan("Container '$name' is in use but the port differs\n  ${ls_nodes[$name]['raw']}")
+      }
+
+      return true
+    }
+  }
+
   return false
 }

--- a/plans/in_one_container/reset_admin_password.pp
+++ b/plans/in_one_container/reset_admin_password.pp
@@ -1,18 +1,38 @@
 # @summary Manage a Pulp-in-one-container
 # @param targets A single target to run on (the container host)
 plan pulp3::in_one_container::reset_admin_password (
-  TargetSpec           $targets         = "localhost",
-  String[1]            $container_name  = lookup('pulp3::in_one_container::container_name')|$k|{'pulp'},
-  Optional[Sensitive[String[1]]] $admin_password  = Sensitive.new(system::env('PULP3_ADMIN_PASSWORD').lest||{'admin'}),
-  Optional[Enum[podman,docker]] $runtime = undef,
+  TargetSpec                     $targets        = "localhost",
+  String[1]                      $container_name = lookup('pulp3::in_one_container::container_name')|$k|{'pulp'},
+  Integer                        $max_retries    = 10,
+  Integer                        $sleep_seconds  = 2,
+  Optional[Sensitive[String[1]]] $admin_password = Sensitive.new(system::env('PULP3_ADMIN_PASSWORD').lest||{'admin'}),
+  Optional[Enum[podman,docker]]  $runtime        = undef,
+
 ) {
   $host = run_plan('pulp3::in_one_container::get_host', 'targets' => $targets, 'runtime' => $runtime)
   $runtime_exe = $host.facts['pioc_runtime_exe']
 
   $admin_reset_cmd = "/bin/sh -c '${runtime_exe} exec ${container_name} bash -c \"pulpcore-manager reset-admin-password -p \$PULP3_ADMIN_PASSWORD\"'"
-  out::message( "Running:\n\n\t${admin_reset_cmd}\n" )
-  $reset_result = run_command($admin_reset_cmd, $host, {
-    '_env_vars' => { 'PULP3_ADMIN_PASSWORD' => $admin_password.unwrap },
-  })
-  return $reset_result
+  log::debug( "Running:\n\n\t${admin_reset_cmd}\n" )
+
+  range(1, $max_retries).each |Integer $x| {
+    log::info("Attempt $x of $max_retries to set the admin password")
+
+    $cmd_result = run_command($admin_reset_cmd, $host, {
+      '_env_vars'     => { 'PULP3_ADMIN_PASSWORD' => $admin_password.unwrap },
+      '_catch_errors' => true
+    })
+
+    if $cmd_result.ok {
+      return $cmd_result
+    }
+    else {
+      log::error("Could not set admin password, sleeping $sleep_seconds seconds")
+      run_command("sleep $sleep_seconds", $host)
+    }
+
+    if $x == $max_retries{
+      return $reset_result
+    }
+  }
 }

--- a/plans/in_one_container/volumes/create.pp
+++ b/plans/in_one_container/volumes/create.pp
@@ -79,9 +79,11 @@ plan pulp3::in_one_container::volumes::create (
     }
     | SETTINGS
 
-  $tmp_container_out = run_command("${runtime_exe} run -id --name pulp_tmp --volume pulp-settings:/pulp centos:8", $host)
+  catch_errors() || {
+    $tmp_container_out = run_command("${runtime_exe} run -id --name ${container_name}_tmp --volume ${container_name}-settings:/pulp centos:8", $host)
 
-  $create_settings_py_out = run_command("(${runtime_exe} exec -i pulp_tmp sh -c 'cat > /pulp/settings.py') << EOM\n${pulp_settings}\nEOM", $host)
+    $create_settings_py_out = run_command("(${runtime_exe} exec -i ${container_name}_tmp sh -c 'cat > /pulp/settings.py') << EOM\n${pulp_settings}\nEOM", $host)
+  }
 
-  $destroy_tmp_container_out = run_command("${runtime_exe} rm -f pulp_tmp", $host)
+  $destroy_tmp_container_out = run_command("${runtime_exe} rm -f ${container_name}_tmp", $host)
 }


### PR DESCRIPTION
* Fix volume names when using an alternate container name
* Raise an error if attempting to start a container that already exists but with
  a different port
* Add a retry on setting the admin password which fixes failures on some systems
* Always attempt to clean up the 'tmp' volume container